### PR TITLE
Add support for userUpdate per PHP implementation

### DIFF
--- a/lib/realm.js
+++ b/lib/realm.js
@@ -248,6 +248,25 @@ function Realm(realmKeyId, realmSecret, inApiUrl) {
     });
   }
 
+  /**
+   * Update a user from the given realm
+   *
+   * @param {string} userId User id to update by
+   * @return {Promise.<Object>} The Tozny_API_User object if successful, otherwise false.
+   */
+  function userUpdate(userId, extraFields) {
+    var extraFieldsArg = new Buffer(JSON.stringify(extraFields)).toString('base64');
+
+    return rawCall('realm.user_update', { user_id: userId, extra_fields: extraFieldsArg }).then(function(resp) {
+      if (resp.return !== 'ok') {
+        return when.reject(resp);
+      }
+      else {
+        return resp;  // TODO: Should we pull a user object out of the response?
+      }
+    });
+  }
+
   _.assign(this, {
     /**
      * @property {String}
@@ -272,6 +291,7 @@ function Realm(realmKeyId, realmSecret, inApiUrl) {
     userEmailExists:   userEmailExists,
     userAdd:           userAdd,
     userGet:           userGet,
+    userUpdate:        userUpdate,
     rawCall:           rawCall
   });
 


### PR DESCRIPTION
Example:

```
realm.userUpdate('sid_xyzzz', { arbitrary_key: 'I did it!' }).then(function(user) {
    // user is response, though metadata lags behind (until you requery, the value you set actually shows up in the fields for the user, not the metadata)
  });
```
